### PR TITLE
Deprecate Jaspersoft Studio recipes

### DIFF
--- a/JaspersoftStudio/JaspersoftStudio.download.recipe.yaml
+++ b/JaspersoftStudio/JaspersoftStudio.download.recipe.yaml
@@ -7,6 +7,10 @@ Input:
   NAME: Jaspersoft Studio
 
 Process:
+  - Processor: DeprecationWarning
+    Arguments:
+      warning_message: The latest version of Jaspersoft Studio requires a login to download. This recipe is deprecated and will be removed in the future.
+
   - Processor: com.github.n8felton.shared/SourceForgeBestReleaseURLProvider
     Arguments:
       SOURCEFORGE_PROJECT_NAME: jasperstudio


### PR DESCRIPTION
This PR deprecates the Jaspersoft Studio recipes, which are no longer publicly downloadable.
